### PR TITLE
ShaderWriter: Fixed sdw::ReturnWrapper with sdw::Void

### DIFF
--- a/include/ShaderWriter/BaseTypes/ReturnWrapper.hpp
+++ b/include/ShaderWriter/BaseTypes/ReturnWrapper.hpp
@@ -30,8 +30,6 @@ namespace sdw
 		sdw::expr::ExprPtr release()const;
 		expr::ExprPtr makeCondition();
 
-		operator ValueT &&();
-
 		static ast::type::TypePtr makeType( ast::type::TypesCache & cache );
 
 	private:

--- a/include/ShaderWriter/BaseTypes/ReturnWrapper.inl
+++ b/include/ShaderWriter/BaseTypes/ReturnWrapper.inl
@@ -74,12 +74,6 @@ namespace sdw
 	}
 
 	template< typename ValueT >
-	ReturnWrapperT< ValueT >::operator ValueT &&()
-	{
-		return ValueT{ *this->getWriter(), release(), this->isEnabled() };
-	}
-
-	template< typename ValueT >
 	ast::type::TypePtr ReturnWrapperT< ValueT >::makeType( ast::type::TypesCache & cache )
 	{
 		return ValueT::makeType( cache );

--- a/include/ShaderWriter/BaseTypes/Void.hpp
+++ b/include/ShaderWriter/BaseTypes/Void.hpp
@@ -17,7 +17,8 @@ namespace sdw
 		SDW_API Void( ShaderWriter & writer
 			, expr::ExprPtr expr
 			, bool enabled = true );
-		SDW_API explicit Void( ReturnWrapperT< Void > && rhs );
+		// Intently non explicit
+		SDW_API Void( ReturnWrapperT< Void > && rhs );
 
 		SDW_API ~Void()override = default;
 		SDW_API Void( Void && rhs ) = default;


### PR DESCRIPTION
The function call was not written in the following case:
```cpp
sdw::Function< sdw::Void, ... > func;
sdw::Void caller( ... )
{
  return func( ... );
}
```