### PR TITLE
NonSemanticDebug: Now forwarding parent scope variables to children scopes.

### DIFF
--- a/source/CompilerSpirV/SpirVBlock.cpp
+++ b/source/CompilerSpirV/SpirVBlock.cpp
@@ -34,6 +34,7 @@ namespace spirv
 		, blockEnd{ std::move( rhs.blockEnd ) }
 		, allocator{ rhs.allocator }
 		, variables{ std::move( rhs.variables ) }
+		, declaredVariables{ std::move( rhs.declaredVariables ) }
 		, accessChains{ std::move( rhs.accessChains ) }
 		, isInterrupted{ rhs.isInterrupted }
 	{
@@ -49,6 +50,7 @@ namespace spirv
 		blockEnd = std::move( rhs.blockEnd );
 		allocator = rhs.allocator;
 		variables = std::move( rhs.variables );
+		declaredVariables = std::move( rhs.declaredVariables );
 		accessChains = std::move( rhs.accessChains );
 		isInterrupted = rhs.isInterrupted;
 
@@ -65,6 +67,7 @@ namespace spirv
 		, instructions{ alloc }
 		, allocator{ alloc }
 		, variables{ ast::StlMapAllocatorT< DebugId, DebugId >{ alloc } }
+		, declaredVariables{ ast::StlAllocatorT< DebugId >{ alloc } }
 		, accessChains{ ast::StlPairAllocatorT< DebugIdList, DebugId >{ alloc } }
 	{
 	}

--- a/source/CompilerSpirV/SpirVBlock.hpp
+++ b/source/CompilerSpirV/SpirVBlock.hpp
@@ -92,6 +92,7 @@ namespace spirv
 		// Used during construction.
 		ast::ShaderAllocatorBlock * allocator;
 		ast::Map< DebugId, DebugId > variables;
+		ast::Vector< DebugId > declaredVariables;
 		ast::Vector< std::pair< DebugIdList, DebugId > > accessChains;
 		bool isInterrupted{};
 	};

--- a/source/CompilerSpirV/SpirVFunction.cpp
+++ b/source/CompilerSpirV/SpirVFunction.cpp
@@ -14,6 +14,7 @@ namespace spirv
 		, debugStart{ ast::StlAllocatorT< InstructionPtr >{ alloc } }
 		, promotedParams{ alloc }
 		, registeredVariables{ ast::StlMapAllocatorT< std::string, VariableInfo >{ alloc } }
+		, debugParams{ ast::StlAllocatorT< DebugId >{ alloc } }
 	{
 	}
 

--- a/source/CompilerSpirV/SpirVFunction.hpp
+++ b/source/CompilerSpirV/SpirVFunction.hpp
@@ -137,6 +137,7 @@ namespace spirv
 		InstructionList debugStart;
 		Block promotedParams;
 		ast::Map< std::string, VariableInfo, std::less<> > registeredVariables;
+		ast::Vector< DebugId > debugParams;
 	};
 
 	using FunctionList = ast::Vector< Function >;

--- a/source/CompilerSpirV/SpirVModule.hpp
+++ b/source/CompilerSpirV/SpirVModule.hpp
@@ -209,6 +209,8 @@ namespace spirv
 			, glsl::Statement const * scopeBeginDebugStatement
 			, glsl::Statement const * firstLineStatement );
 		SDWSPIRV_API Block newBlock();
+		SDWSPIRV_API void importParentBlockVars( Block & block
+			, ast::Vector< DebugId > const & parentVariables );
 		SDWSPIRV_API void endFunction();
 
 		SDWSPIRV_API spv::Id getNextId();

--- a/source/CompilerSpirV/SpirVNonSemanticDebug.hpp
+++ b/source/CompilerSpirV/SpirVNonSemanticDebug.hpp
@@ -74,24 +74,26 @@ namespace spirv::debug
 		//
 		// Variables declarations
 		//
-		void declareVariable( InstructionList & instructions
+		void declareLocalVariable( InstructionList & instructions
+			, DebugId const & variableId );
+		DebugId declareVariable( InstructionList & instructions
 			, std::string const & name
 			, ast::type::TypePtr type
 			, DebugId variableId
 			, DebugId initialiser
 			, glsl::Statement const * debugStatement
 			, bool isAccessChain = false );
-		void declarePointerParam( InstructionList & instructions
+		DebugId declarePointerParam( InstructionList & instructions
 			, std::string const & name
 			, ast::type::TypePtr type
 			, DebugId variableId
 			, DebugId initialiser
 			, glsl::Statement const * debugStatement );
-		void declareAccessChain( InstructionList & instructions
+		DebugId declareAccessChain( InstructionList & instructions
 			, ast::expr::Expr const & expr
 			, glsl::Statement const * debugStatement
 			, DebugId & resultId );
-		void declareFunction( Function & function
+		ast::Vector< DebugId > declareFunction( Function & function
 			, std::string const & name
 			, ast::var::VariableList const & params
 			, DebugIdList const & funcParams


### PR DESCRIPTION
It allows for RenderDoc to track those variables through scopes.