### PR TITLE
SSA: Fixed while to do...while conversion regarding aliases created in condition expr

### DIFF
--- a/source/ShaderAST/Visitors/TransformSSA.cpp
+++ b/source/ShaderAST/Visitors/TransformSSA.cpp
@@ -1274,13 +1274,21 @@ namespace ast
 				TraceFunc;
 				auto ifStmt = m_stmtCache.makeIf( doSubmit( stmt->getCtrlExpr() ) );
 				{
-					// Do ... while content
-					auto doWhileContent = m_stmtCache.makeDoWhile( doSubmit( stmt->getCtrlExpr() ) );
 					auto save = m_current;
-					m_current = doWhileContent.get();
-					visitContainerStmt( stmt );
+					m_current = ifStmt.get();
+					// Do ... while content
+					{
+						auto doWhileContent = m_stmtCache.makeContainer();
+						m_current = doWhileContent.get();
+						visitContainerStmt( stmt );
+						// Declare the do...while after its content, so that aliases
+						// created from its control expression are declared inside its content.
+						auto doWhile = m_stmtCache.makeDoWhile( doSubmit( stmt->getCtrlExpr() ) );
+						m_current = ifStmt.get();
+						doWhile->addStmt( std::move( doWhileContent ) );
+						ifStmt->addStmt( std::move( doWhile ) );
+					}
 					m_current = save;
-					ifStmt->addStmt( std::move( doWhileContent ) );
 				}
 				m_current->addStmt( std::move( ifStmt ) );
 			}


### PR DESCRIPTION
They were all created before the generated if expr, resulting in loop condition remaining unchanged. The ones used in the while condition are now generated after all the loop content.