### PR TITLE
Remove incorrect ::template followed by no template arguments.

### DIFF
--- a/include/ShaderWriter/CompositeTypes/StructInstanceHelper.hpp
+++ b/include/ShaderWriter/CompositeTypes/StructInstanceHelper.hpp
@@ -61,7 +61,7 @@ namespace sdw
 		{
 			static_assert( hasFieldByName< FieldNameT >() );
 			using FieldT = decltype( getFieldByName< FieldNameT >() );
-			return FieldT::template get( *this );
+			return FieldT::get( *this );
 		}
 
 		static type::BaseStructPtr makeType( type::TypesCache & cache )


### PR DESCRIPTION
Resolves build failure on macOS 15.6.1:

```console
/Users/vcpkg/vcpkg/buildtrees/shaderwriter/src/v2.9.0-c5b41d7ff1.clean/include/ShaderWriter/CompositeTypes/StructInstanceHelper.hpp:64:28: error: a template argument list is expected after a name prefixed by the template keyword [-Wmissing-template-arg-list-after-template-kw]
   64 |                         return FieldT::template get( *this );
      |                                                 ^
```